### PR TITLE
change bottle_mongodb to bottle_mongo to match pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 requires = [
     'bottle',
-    'bottle_mongodb',
+    'bottle_mongo',
     'pymongo'
 ]
 


### PR DESCRIPTION
The package name was changed on PyPI, so `bottle_mongodb` will forever be
`0.2.3` which is the version that doesn't include the fixes we submitted.
Update the package name to match the newer version.
